### PR TITLE
feat: Add cli generator

### DIFF
--- a/build-markdown-generator-cli/pom.xml
+++ b/build-markdown-generator-cli/pom.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<!--
+
+    Copyright 2017 Anton Johansson
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.anton-johansson</groupId>
+        <artifactId>build-markdown-generator</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+    <artifactId>build-markdown-generator-cli</artifactId>
+    <packaging>jar</packaging>
+    <name>Anton Johansson :: Build Markdown Generator :: CLI</name>
+    <description>Initiates the generation of markdown through a command line interface</description>
+
+    <properties>
+    </properties>
+
+    <dependencies>
+        <!-- Internal modules -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>build-markdown-generator-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- External libraries -->
+        <dependency>
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
+            <version>1.5.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>com.antonjohansson.bmg.cli.Main</mainClass>
+                        </manifest>
+                    </archive>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                    <appendAssemblyId>false</appendAssemblyId>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/build-markdown-generator-cli/src/main/java/com/antonjohansson/bmg/cli/Main.java
+++ b/build-markdown-generator-cli/src/main/java/com/antonjohansson/bmg/cli/Main.java
@@ -1,0 +1,112 @@
+package com.antonjohansson.bmg.cli;
+
+import com.antonjohansson.bmg.core.InputConfig;
+import com.antonjohansson.bmg.core.OutputConfig;
+import com.antonjohansson.bmg.core.Runner;
+import org.apache.commons.cli.*;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+/**
+ * @author Arturo Volpe
+ * @since 2022-09-02
+ */
+public class Main {
+
+    public static void main(String[] args) throws ParseException {
+
+        Options options = new Options();
+
+        options.addOption("root", true, "Root folder");
+
+        options.addOption("detailedReportURL", true, "URL of the detailed report (HTML)");
+
+        options.addOption("checkstyleReportPatterns", true, "List of pattern for checkstyle reports");
+        options.addOption("checkstyleDetailedReportURL", true, "URL of the detailed report for checkstyle");
+
+        options.addOption("junitReportPatterns", true, "List of patterns for junit reports");
+        options.addOption("junitDetailedReportURL", true, "URL of the detailed report for junit");
+        options.addOption("junitDetailedReportForTestURL", true, "URL for the detailed report for a single junit test url");
+
+        options.addOption("outputFile", true, "Path of the result, default ./build-markdown.md");
+
+        options.addOption("coberturaCoverageReport", true, "Path to the cobertura report");
+        options.addOption("coberturaLineThreshold", true, "Line threshold for cobertura, default 0");
+        options.addOption("coberturaBranchThreshold", true, "Branch threshold for cobertura, default 0");
+        options.addOption("coberturaDetailedReportURL", true, "URL of the detailed report of cobertura");
+
+        options.addOption("help", false, "Print the help");
+        options.addOption("template", true, "The output template");
+
+        CommandLineParser parser = new DefaultParser();
+        CommandLine cmd = parser.parse(options, args);
+
+        if (cmd.hasOption("help")) {
+            HelpFormatter formatter = new HelpFormatter();
+            formatter.printHelp("java -jar build-markdown-generator-cli.jar", options);
+            return;
+        }
+
+        InputConfig input = new InputConfig();
+
+        input.setRoot(new File(cmd.getOptionValue("root", ".")));
+        input.setDetailedReportURL(cmd.getOptionValue("detailedReportURL"));
+
+        input.setCheckstyleReportPatterns(toList(cmd, "checkstyleReportPatterns"));
+        input.setCheckstyleDetailedReportURL(cmd.getOptionValue("checkstyleDetailedReportURL"));
+
+        input.setJunitReportPatterns(toList(cmd, "junitReportPatterns"));
+        input.setJunitDetailedReportURL(cmd.getOptionValue("junitDetailedReportURL"));
+        input.setJunitDetailedReportForTestURL(cmd.getOptionValue("junitDetailedReportForTestURL"));
+
+        input.setCoberturaCoverageReport(cmd.getOptionValue("coberturaCoverageReport"));
+        input.setCoberturaLineThreshold(new BigDecimal(cmd.getOptionValue("coberturaLineThreshold", "0")));
+        input.setCoberturaBranchThreshold(new BigDecimal(cmd.getOptionValue("coberturaBranchThreshold", "0")));
+        input.setCoberturaDetailedReportURL(cmd.getOptionValue("coberturaDetailedReportURL"));
+
+        OutputConfig output = new OutputConfig();
+        output.setTemplate(getContent(cmd.getOptionValue("template")));
+
+
+        Runner runner = new Runner();
+        System.out.println("Generating markdown...");
+
+        String markdown = runner.run(input, output);
+
+        System.out.println("Successfully generated markdown");
+        System.out.println(markdown);
+
+        try {
+            FileUtils.write(Paths.get(cmd.getOptionValue("outputFile", "./build-markdown.md")).toFile(), markdown, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new RuntimeException("Could not write the generated markdown to the outputFile", e);
+        }
+    }
+
+    private static List<String> toList(CommandLine cmd, String checkstyleReportPatterns) {
+        String[] options = cmd.getOptionValues(checkstyleReportPatterns);
+        if (options == null || options.length == 0) return Collections.emptyList();
+        return Arrays.asList(options);
+    }
+
+    private static String getContent(String template) {
+
+        if (isBlank(template)) return null;
+        try {
+            return IOUtils.toString(Paths.get(template).toUri(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new RuntimeException("Can't read template: " + template, e);
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,7 @@
     <modules>
         <module>build-markdown-generator-core</module>
         <module>build-markdown-generator-maven-plugin</module>
+        <module>build-markdown-generator-cli</module>
     </modules>
 
     <build>


### PR DESCRIPTION
A new module is added that uses apache common cli to expose a cli
interface to generate the markdown without a maven project.

Example usage:

```bash
java -jar path-to-cli.jar \
    -root /path/to/gradle/project \
    -junitReportPatterns '**/test-results/TEST-*.xml' \
    -outputFile 'result.md'
```
